### PR TITLE
Update 31.md (Info / .w3i)

### DIFF
--- a/Info/25.md
+++ b/Info/25.md
@@ -28,7 +28,7 @@ File structure:
 * `string` Loading screen text
 * `string` Loading screen title
 * `string` Loading screen subtitle
-* `int` Game data set (0=standard)
+* `int` Game data set (0 = Default (based on map melee status); 1 = Custom (1.01); 2 = Melee (Latest patch))
 * `string` Prologue path
 * `string` Prologue text
 * `string` Prologue title

--- a/Info/31.md
+++ b/Info/31.md
@@ -2,10 +2,10 @@ File structure:
 * `int` File version = 0x1F (31)
 * `int` Number of saves
 * `int` Editor version
-* `unknown(4)`
-* `unknown(4)`
-* `unknown(4)`
-* `unknown(4)`
+* `int` Game version major
+* `int` Game version minor
+* `int` Game version patch
+* `int` Game version build
 * `string` Map name
 * `string` Map author
 * `string` Map description
@@ -54,7 +54,7 @@ File structure:
 * `byte` Water color - A
 * `int` Script language (0=JASS, 1=Lua)
 * `int` Supported modes (1=SD, 2=HD, 3=SD+HD)
-* `unknown(4)` 
+* `int` Game data version (0=ROC, 1=TFT)
 * `int` Number of players
   * `int` Player number
   * `int` Player type (1=Human, 2=Computer, 3=Neutral, 4=Rescuable)

--- a/Info/31.md
+++ b/Info/31.md
@@ -32,7 +32,7 @@ File structure:
 * `string` Loading screen text
 * `string` Loading screen title
 * `string` Loading screen subtitle
-* `int` Game data set (0=standard)
+* `int` Game data set (0 = Default (based on map melee status); 1 = Custom (1.01); 2 = Melee (Latest patch))
 * `string` Prologue path
 * `string` Prologue text
 * `string` Prologue title


### PR DESCRIPTION
Add undocumented:

Four ints: **Game version** (was already documented elsewhere). Example: 1.31.1.12173

and one int: **Game data version** (0=ROC, 1=TFT) (new). This is the setting from WE > Scenario > Map Options

I don't know what happened to cause a change on L94

----
Game data set:

In the 1.26 WE, the `Game data set` option for mode=1 is described as: "Custom 1.07 TFT / 1.01 ROC"

I think the game selects the appropriate game data version by examining:

> * `int` Game data version (0=ROC, 1=TFT)

This field was added in format >=31